### PR TITLE
Fix Levenshtein ratio

### DIFF
--- a/report.py
+++ b/report.py
@@ -64,7 +64,7 @@ def levenshtein_ratio(s, t):
             distance[row][col] = min(distance[row - 1][col] + 1,
                                      distance[row][col - 1] + 1,
                                      distance[row - 1][col - 1] + cost)
-    ratio = ((len(s) + len(t)) - distance[len(s)][len(t)]) / (len(s) + len(t))
+    ratio = ((len(s) + len(t)) - distance[-1][-1]) / (len(s) + len(t))
     return 100 * ratio
 
 

--- a/report.py
+++ b/report.py
@@ -47,21 +47,24 @@ class Field(IntEnum):
 
 
 def levenshtein_ratio(s, t):
+    if not len(s) and not len(t):
+        return 100.0
+
     rows = len(s) + 1
     cols = len(t) + 1
     distance = np.zeros((rows, cols), dtype=int)
-    distance[0, :] = np.arange(1, cols + 1)
-    distance[:, 0] = np.arange(1, rows + 1)
+    distance[0, :] = np.arange(0, cols)
+    distance[:, 0] = np.arange(0, rows)
     for col in range(1, cols):
         for row in range(1, rows):
             if s[row - 1] == t[col - 1]:
                 cost = 0
             else:
-                cost = 2
+                cost = 1
             distance[row][col] = min(distance[row - 1][col] + 1,
                                      distance[row][col - 1] + 1,
                                      distance[row - 1][col - 1] + cost)
-    ratio = ((len(s) + len(t)) - distance[row][col]) / (len(s) + len(t))
+    ratio = ((len(s) + len(t)) - distance[len(s)][len(t)]) / (len(s) + len(t))
     return 100 * ratio
 
 


### PR DESCRIPTION
- Previously, the ratio would be calculated wrong due to the set cost of **2** instead of **1**.
- Previously, local variables `row` and `col` were used after the for loops, which is dangerous, as these variables are not assigned if the for loops do not get executed
- Also, it would crash on empty string due to division by zero

I changed the implementation to be consistent with [Wikipedia](https://en.wikipedia.org/wiki/Levenshtein_distance) (except that the formula for ratio uses this distance)